### PR TITLE
PHOTO and LOGO properties should use semicolon

### DIFF
--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -238,8 +238,8 @@ ${name};${extended};${street};${city};${region};${zip};${country}\
 
     this.setProperty(
       element,
-      property,
-      `ENCODING=b;TYPE=${mime.toUpperCase()}:${content}`,
+      `${property};ENCODING=b;TYPE=${mime.toUpperCase()}`,
+      content,
     )
 
     return this


### PR DESCRIPTION
When creating a vCard with a logo or photo, it does not appear when opening the card/saving to contacts.  Changing the colon to a semicolon as per RFC2426 fixes this issue