### PR TITLE
[Fix] Number type required for phone numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.2
+
+> Jan 9, 2022
+
+- Fixes the issue with the `addPhoneNumber()` method only accepting `number` as
+  a parameter, making it impossible to pass leading zeros ([#27](https://github.com/joaocarmo/vcard-creator/issues/27))
+
 ## 0.4.1 (no release)
 
 > Jul 10, 2021

--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -314,14 +314,14 @@ ${lastName};${firstName};${additional};${prefix};${suffix}\
   /**
    * Add phone number
    *
-   * @param  {string} number
+   * @param  {number | string} number
    * @param  {string} [type='']
    * 'type' may be PREF | WORK | HOME | VOICE | FAX | MSG |
    * CELL | PAGER | BBS | CAR | MODEM | ISDN | VIDEO
    * or any senseful combination, e.g. 'PREF;WORK;VOICE'
    * @return {this}
    */
-  public addPhoneNumber(number: number, type = ''): this {
+  public addPhoneNumber(number: number | string, type = ''): this {
     this.setProperty(
       'phoneNumber',
       `TEL${type !== '' ? `;${type}` : ''}`,

--- a/lib/__tests__/VCard.test.ts
+++ b/lib/__tests__/VCard.test.ts
@@ -130,7 +130,7 @@ END:VCALENDAR
     clear()
   })
 
-  it('shoud throw on attempting to add the same property', () => {
+  it('should throw on attempting to add the same property', () => {
     // Define vCard
     const vCard = new VCard()
 
@@ -143,12 +143,40 @@ END:VCALENDAR
     }).toThrow(VCardException)
   })
 
-  it('shoud throw on attempting to add an invalid MIME Media Type', () => {
+  it('should throw on attempting to add an invalid MIME Media Type', () => {
     // Define vCard
     const vCard = new VCard()
 
     expect(() => {
       vCard.addPhoto('MIICajCCAdOgAwIBAgICBEUwDQYJKoZIhvcN...', 'foobar')
     }).toThrow(VCardException)
+  })
+
+  it('shoud parse phone numbers correctly', () => {
+    // Setup a fixed date
+    advanceTo(new Date())
+
+    // Define vCard
+    const vCard = new VCard()
+
+    // Add phone numbers
+    vCard
+      .addPhoneNumber(1234121212, 'PREF;WORK')
+      .addPhoneNumber(123456789, 'WORK')
+      .addPhoneNumber('0123456789', 'HOME')
+
+    const vCardOutput = vCard.toString()
+    const expectedOutput = `\
+BEGIN:VCARD\r\n\
+VERSION:3.0\r\n\
+REV:${new Date().toISOString()}\r\n\
+TEL;PREF;WORK:1234121212\r\n\
+TEL;WORK:123456789\r\n\
+TEL;HOME:0123456789\r\n\
+END:VCARD\r\n\
+`
+
+    // Compare the results
+    expect(vCardOutput).toBe(expectedOutput)
   })
 })


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [x] Fix #27
- [ ] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

<!-- Please replace {Please write here ...} with something useful -->

Fixes the issue with the `addPhoneNumber()` method only accepting `number` as a parameter, making it impossible to pass leading zeros.

### Change description

<!-- Please replace {Please write here ...} with something useful -->

- Adds `number | string` as an acceptable parameter type

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [x] Tests passed
- [x] Coding style respected
