### PR TITLE
chore(vCard): deprecate `vcalendar` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ vCard.addPhoto(image, 'JPEG')
 
 Include the proper [MIME type][mime-types] (defaults to `JPEG`).
 
-### iCalendar format
+### [DEPRECATED] iCalendar format
 
 For Apple devices that don't support the `vcf` file format, there is a
 workaround. Specify the format of the output as `vcalendar` and then save it

--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -494,7 +494,7 @@ ${lastName};${firstName};${additional};${prefix};${suffix}\
   public buildVCalendar(): string {
     // eslint-disable-next-line no-console
     console.warn(
-      `The format 'vcalendar' is deprecated and will be removed in the next major or minor release. Use 'vcard' instead.`,
+      `The method 'buildVCalendar' is deprecated and will be removed in the next major or minor release. Use 'buildVCard' instead.`,
     )
 
     const nowISO = new Date().toISOString()

--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -87,6 +87,10 @@ export default class VCard {
    */
   public setFormat(format: Format = constants.DEFAULT_FORMAT): void {
     if (format === constants.Formats.VCALENDAR) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `The format 'vcalendar' is deprecated and will be removed in the next major or minor release. Use 'vcard' instead.`,
+      )
       this.contentType = constants.ContentTypes.VCALENDAR
       this.useVCalendar = true
     } else if (format === constants.Formats.VCARD) {
@@ -488,6 +492,11 @@ ${lastName};${firstName};${additional};${prefix};${suffix}\
    * @return {string}
    */
   public buildVCalendar(): string {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `The format 'vcalendar' is deprecated and will be removed in the next major or minor release. Use 'vcard' instead.`,
+    )
+
     const nowISO = new Date().toISOString()
     const nowBase = nowISO.replace(/-/g, '').replace(/:/g, '').substring(0, 13)
     const dtstart = `${nowBase}00`

--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -479,9 +479,12 @@ ${lastName};${firstName};${additional};${prefix};${suffix}\
   }
 
   /**
-   * Build VCalender (.ics) - Safari (< iOS 8) can not open .vcf files, so we
-   * have build a workaround.
+   * Build VCalender (.ics) - Safari (< iOS 7) can not open .vcf files, so we
+   * built a workaround.
    *
+   * @deprecated This method is deprecated and will be removed in the next major
+   * or minor release. Use `buildVCard` instead. For more information, see
+   * https://stackoverflow.com/a/11405271/8713532.
    * @return {string}
    */
   public buildVCalendar(): string {

--- a/lib/utils/constants.ts
+++ b/lib/utils/constants.ts
@@ -1,11 +1,13 @@
 import { Element } from '../types/VCard'
 
 export enum ContentTypes {
+  /** @deprecated */
   VCALENDAR = 'text/x-vcalendar',
   VCARD = 'text/x-vcard',
 }
 
 export enum Formats {
+  /** @deprecated */
   VCALENDAR = 'vcalendar',
   VCARD = 'vcard',
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preinstall": "npx only-allow pnpm",
     "pretty:fix": "prettier --write .",
     "pretty": "prettier --check .",
-    "test:functional": "(./test-functional/test-vcard.js | tee vcard.vcf) && (./test-functional/test-vcalendar.js | tee vcard.ics)",
+    "test:functional": "(./test-functional/test-vcard.js | tee vcard.vcf) && (./test-functional/test-vcalendar.js 2>/dev/null | tee vcard.ics)",
     "test:unit": "jest",
     "test:web-build": "NODE_ENV=development webpack --mode development && open ./test-functional/test-build.html",
     "test:web-export": "open ./test-functional/test-export.html",


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

Deprecates the `vcalendar` format. This will be removed in the next major or minor release. For more information, see https://github.com/joaocarmo/vcard-creator/issues/26#issuecomment-1215066860 and https://stackoverflow.com/a/11405271/8713532.

**Note:** deprecation console warnings were added for methods that invoke related methods.

Resolves #53.

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [x] Tests passed
- [x] Coding style respected
