### PR TITLE
Fix issue that unnecessary semicolons being added to the address of t…

### DIFF
--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -123,9 +123,12 @@ export default class VCard {
     country: string = '',
     type: string = 'WORK;POSTAL',
   ): this {
-    const value = `\
-${name};${extended};${street};${city};${region};${zip};${country}\
-`
+    const value = [name, extended, street, city, region, zip, country]
+      .filter((part) => part !== null && part !== '')
+      .join(';')
+
+    if (value === '') return this
+
     this.setProperty(
       'address',
       `ADR${type !== '' ? `;${type}` : ''}${this.getCharsetString()}`,


### PR DESCRIPTION
…he vcf when the addAddress method parameters has empty or null (#60)

<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Chore
- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

<!-- Please replace {Please write here ...} with something useful -->

Fix issue that unnecessary semicolons being added to the address of the vcf when the addAddress method parameters has empty or null

### Change description

<!-- Please replace {Please write here ...} with something useful -->

As you can see in the screenshot below, there is 'null' and unnecessary ';' characters appears when the addAddress method's args has null values.

like this ⬇ 

``` js
.addAddress(
    'name',
    'extended',
    null,
    'worktown',
    'state',
    undefined,
    'Belgium',
)
```

![Image](https://github.com/user-attachments/assets/4e1b13df-64cf-47dc-b053-1a3dbe63c837)

So i've fixed this issue by pushing all parameters to an array and then filter good values among them and join them to one string with ';'.

``` js
  public addAddress(
    name: string = '',
    extended: string = '',
    street: string = '',
    city: string = '',
    region: string = '',
    zip: string = '',
    country: string = '',
    type: string = 'WORK;POSTAL',
  ): this {
    const value = [name, extended, street, city, region, zip, country]
      .filter((part) => part !== null && part !== '')
      .join(';')

    if (value === '') return this

    this.setProperty(
      'address',
      `ADR${type !== '' ? `;${type}` : ''}${this.getCharsetString()}`,
      value,
    )

    return this
  }
```

![Image](https://github.com/user-attachments/assets/bb03d15a-7a28-45ae-991a-1145eb45357e)

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [x] Tests passed
- [x] Coding style respected
