### PR TITLE
Add Build to ESM option for users wanting ESM but not a CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build:types": "tsc -p tsconfig.declaration.json && mv dist/index.d.ts dist/vcard-creator.d.ts",
     "build": "NODE_ENV=production webpack --mode production",
+    "build:esm": "tsc -p tsconfig.esm.json",
     "clean": "rimraf ./dist/ ./node_modules/.cache/ *.vcf *.ics",
     "lint:fix": "eslint . --fix",
     "lint": "eslint .",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "files": ["lib/index.ts"]
+}


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Chore
- [ x ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

I work at a hospital conglomerate who's security policies forbid using CDN's. I therefore had to write this scripting option to get the project built as an ESM module which I've uploaded to our internal npm packages. Providing this pull request on the off chance that having this build option would be useful for others. It might also be nice if a vcard-creator-esm package was set up as well instead of relying on Skypack to provide them.

