### PR TITLE
Allow to set custom PRODID

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,19 @@ vCard.addKey({ key: base64cert, mime: 'X509' })
 
 ### Other
 
-| Method                      | Description                                                                         |
-| --------------------------- | ----------------------------------------------------------------------------------- |
-| `addUid(uid)`               | Unique identifier                                                                   |
-| `addCategories(categories)` | Categories/tags — accepts `string[]`                                                |
-| `addNote(note)`             | Free-text note                                                                      |
-| `addSortString(sortString)` | Sort key for name ordering ([RFC 2426 §3.6.5][rfc2426-sort]) — useful for CJK names |
-| `addRevision(date)`         | Revision timestamp — accepts `Date`. Overrides auto-generated `REV`                 |
+| Method                      | Description                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `addUid(uid)`               | Unique identifier                                                                                |
+| `addCategories(categories)` | Categories/tags — accepts `string[]`                                                             |
+| `addNote(note)`             | Free-text note                                                                                   |
+| `addSortString(sortString)` | Sort key for name ordering ([RFC 2426 §3.6.5][rfc2426-sort]) — useful for CJK names              |
+| `addRevision(date)`         | Revision timestamp — accepts `Date`. Overrides auto-generated `REV`                              |
+| `setProdId(prodId)`         | Override the default `PRODID` field. Defaults to `-//vcard-creator//vcard-creator {version}//EN` |
+
+```js
+// Custom PRODID
+myVCard.setProdId('-//MyApp//MyApp 1.0//EN')
+```
 
 ### Custom Properties
 

--- a/lib/VCard.test.ts
+++ b/lib/VCard.test.ts
@@ -135,6 +135,15 @@ describe('PRODID', () => {
     expect(prodidIdx).toBeGreaterThan(versionIdx)
     expect(prodidIdx).toBeLessThan(revIdx)
   })
+
+  it('should use custom PRODID when set via setProdId', () => {
+    const vCard = new VCard()
+    vCard.addName({ familyName: 'Doe', givenName: 'John' })
+    vCard.setProdId('-//MyApp//MyApp 1.0//EN')
+    const output = vCard.toString()
+    expect(output).toContain('PRODID:-//MyApp//MyApp 1.0//EN')
+    expect(output).not.toContain(`PRODID:-//vcard-creator//vcard-creator ${LIB_VERSION}//EN`)
+  })
 })
 
 describe('Metadata getters', () => {

--- a/lib/VCard.ts
+++ b/lib/VCard.ts
@@ -61,6 +61,11 @@ export default class VCard {
   private definedElements: DefinedElements = {}
 
   /**
+   * PRODID string.
+   */
+  private prodId: string = `-//vcard-creator//vcard-creator ${constants.LIB_VERSION}//EN`
+
+  /**
    * Multiple properties for element allowed.
    */
   private multiplePropertiesForElementAllowed: ReadonlySet<Element> =
@@ -605,7 +610,7 @@ export default class VCard {
     const parts: string[] = [
       'BEGIN:VCARD\r\n',
       'VERSION:3.0\r\n',
-      `PRODID:-//vcard-creator//vcard-creator ${constants.LIB_VERSION}//EN\r\n`,
+      `PRODID:${this.prodId}\r\n`,
     ]
 
     if (!this.definedElements['revision']) {
@@ -725,6 +730,13 @@ export default class VCard {
    */
   public setCharset(charset: string): void {
     this.charset = charset
+  }
+
+  /**
+   * Set PRODID.
+   */
+  public setProdId(prodId: string): void {
+    this.prodId = prodId
   }
 
   /**


### PR DESCRIPTION
### Request type

- [ ] Chore
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [x] Tests
- [x] Documentation

### Summary

Add support for overriding the `PRODID` field in the generated vCard output via a new `setProdId` method.

### Change description

A new private `prodId` property has been added to the `VCard` class, initialized with the existing default value (`-//vcard-creator//vcard-creator {version}//EN`). The `buildVCard` method now reads from this property instead of using the hardcoded string.

A new public `setProdId(prodId: string)` method allows consumers to override the default `PRODID` before building the vCard. If `setProdId` is never called, the output is identical to before.

A test case was added to verify that the custom `PRODID` is used when `setProdId` is called, and that it replaces the default value.

### Check lists

- [x] Tests passed
- [x] Coding style respected